### PR TITLE
Add 60 FPS patches for prisoner timer, spray effects, and map transcribe animation

### DIFF
--- a/Patches/MapTranscription.cpp
+++ b/Patches/MapTranscription.cpp
@@ -67,11 +67,11 @@ __declspec(naked) void __stdcall ActiveMarkerStateASM()
         pop eax
         jz HandlerExit
         mov ecx, dword ptr ds : [ZoomOrPanStateAddr]
-        mov dword ptr ds : [ecx] , eax
+        mov dword ptr ds : [ecx], eax
         mov ecx, dword ptr ds : [ActiveMarkerStateAddr]
-        mov dword ptr ds : [ecx] , 0x02
+        mov dword ptr ds : [ecx], 0x02
         mov ecx, dword ptr ds : [PauseCounterAddr]
-        mov dword ptr ds : [ecx] , 0x00
+        mov dword ptr ds : [ecx], 0x00
         jmp HandlerExit
 
     ActiveMarkerState2:
@@ -84,12 +84,12 @@ __declspec(naked) void __stdcall ActiveMarkerStateASM()
         pop eax
         jz HandlerExit
         mov ecx, dword ptr ds : [ZoomOrPanStateAddr]
-        cmp dword ptr ds : [ecx] , 0x02
+        cmp dword ptr ds : [ecx], 0x02
         jnz HandlerExit
         mov ecx, dword ptr ds : [ActiveMarkerStateAddr]
-        mov dword ptr ds : [ecx] , 0x03
+        mov dword ptr ds : [ecx], 0x03
         mov ecx, dword ptr ds : [PauseCounterAddr]
-        mov dword ptr ds : [ecx] , 0x00
+        mov dword ptr ds : [ecx], 0x00
         jmp HandlerExit
 
     ActiveMarkerState3:
@@ -108,9 +108,9 @@ __declspec(naked) void __stdcall ActiveMarkerStateASM()
         pop ebx
         pop eax
         jb HandlerExit
-        mov byte ptr ds : [ecx + edx * 0x08 + 0x04] , 0x80
+        mov byte ptr ds : [ecx + edx * 0x08 + 0x04], 0x80
         mov ecx, dword ptr ds : [ActiveMarkerStateAddr]
-        mov dword ptr ds : [ecx] , 0x04
+        mov dword ptr ds : [ecx], 0x04
         jmp HandlerExit
 
     ActiveMarkerState4:
@@ -132,7 +132,7 @@ __declspec(naked) void __stdcall ActiveMarkerStateASM()
         mov edx, dword ptr ds : [DeltaFrameAddr]
         add ecx, dword ptr ds : [edx]
         pop edx
-        mov dword ptr ds : [eax] , ecx
+        mov dword ptr ds : [eax], ecx
         mov eax, 0x00
         cmp ecx, [esp + 0x8]
         pop ecx

--- a/Patches/MapTranscription.cpp
+++ b/Patches/MapTranscription.cpp
@@ -1,0 +1,210 @@
+/**
+* Copyright (C) 2022 Elisha Riedlinger
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+// Variables for ASM
+DWORD ActiveMarkerStateAddr = 0;
+DWORD PauseCounterAddr = 0;
+DWORD ZoomOrPanStateAddr = 0;
+DWORD MarkerIndexAddr = 0;
+DWORD DeltaFrameAddr = 0;
+DWORD State4ReturnAddr = 0;
+DWORD StateJumpTableAddr = 0;
+
+float ZoomPanTimerMaxValue = 0.99999f;
+
+// ASM which replaces frame timers in the active marker state handler.
+__declspec(naked) void __stdcall ActiveMarkerStateASM()
+{
+    __asm
+    {
+        cmp edx, 0x01
+        je ActiveMarkerState1
+        cmp edx, 0x02
+        je ActiveMarkerState2
+        cmp edx, 0x03
+        je ActiveMarkerState3
+        cmp edx, 0x04
+        je ActiveMarkerState4
+        cmp edx, 0x00
+        jnz HandlerResume
+
+        // Wait 1/30 sec before moving to the next state.
+        push eax
+        push 0x02
+        call PauseForFrames
+        add esp, 0x04
+        test eax, eax
+        pop eax
+        jz HandlerExit
+        jmp HandlerResume
+
+    ActiveMarkerState1:
+        // Wait 17/30 sec before moving to the next state.
+        push eax
+        push 0x22
+        call PauseForFrames
+        add esp, 0x04
+        test eax, eax
+        pop eax
+        jz HandlerExit
+        mov ecx, dword ptr ds : [ZoomOrPanStateAddr]
+        mov dword ptr ds : [ecx] , eax
+        mov ecx, dword ptr ds : [ActiveMarkerStateAddr]
+        mov dword ptr ds : [ecx] , 0x02
+        mov ecx, dword ptr ds : [PauseCounterAddr]
+        mov dword ptr ds : [ecx] , 0x00
+        jmp HandlerExit
+
+    ActiveMarkerState2:
+        // Wait 1/30 sec before checking whether the zoom is complete.
+        push eax
+        push 0x02
+        call PauseForFrames
+        add esp, 0x04
+        test eax, eax
+        pop eax
+        jz HandlerExit
+        mov ecx, dword ptr ds : [ZoomOrPanStateAddr]
+        cmp dword ptr ds : [ecx] , 0x02
+        jnz HandlerExit
+        mov ecx, dword ptr ds : [ActiveMarkerStateAddr]
+        mov dword ptr ds : [ecx] , 0x03
+        mov ecx, dword ptr ds : [PauseCounterAddr]
+        mov dword ptr ds : [ecx] , 0x00
+        jmp HandlerExit
+
+    ActiveMarkerState3:
+        // Fade in active marker.
+        mov edx, dword ptr ds : [MarkerIndexAddr]
+        mov edx, dword ptr ds : [edx]
+        push eax
+        mov eax, dword ptr ds : [DeltaFrameAddr]
+        mov ah, byte ptr ds : [eax]
+        shl ah, 0x02
+        push ebx
+        mov bl, [ecx + edx * 0x08 + 0x04]
+        add bl, ah
+        mov[ecx + edx * 0x08 + 0x04], bl
+        cmp bl, 0x80
+        pop ebx
+        pop eax
+        jb HandlerExit
+        mov byte ptr ds : [ecx + edx * 0x08 + 0x04] , 0x80
+        mov ecx, dword ptr ds : [ActiveMarkerStateAddr]
+        mov dword ptr ds : [ecx] , 0x04
+        jmp HandlerExit
+
+    ActiveMarkerState4:
+        // Wait 5/6 sec before moving to the next state.
+        push eax
+        push 0x32
+        call PauseForFrames
+        add esp, 0x04
+        test eax, eax
+        pop eax
+        jz HandlerExit
+        jmp State4ReturnAddr
+
+    PauseForFrames:
+        push ecx
+        mov eax, dword ptr ds : [PauseCounterAddr]
+        mov ecx, dword ptr ds : [eax]
+        push edx
+        mov edx, dword ptr ds : [DeltaFrameAddr]
+        add ecx, dword ptr ds : [edx]
+        pop edx
+        mov dword ptr ds : [eax] , ecx
+        mov eax, 0x00
+        cmp ecx, [esp + 0x8]
+        pop ecx
+        jge PauseForFramesDone
+        ret
+    PauseForFramesDone:
+        mov eax, 0x01
+        ret
+
+    HandlerResume:
+        mov ebx, dword ptr ds : [StateJumpTableAddr]
+        mov edx, dword ptr ds : [ActiveMarkerStateAddr]
+        mov edx, dword ptr ds : [edx]
+        jmp dword ptr ds : [edx * 0x04 + ebx]
+
+    HandlerExit:
+        pop edi
+        pop esi
+        pop ecx
+        ret
+    }
+}
+
+DWORD GetDeltaFrameAddress()
+{
+    constexpr BYTE SearchBytesDeltaFrame[]{ 0x8B, 0x44, 0x24, 0x04, 0x8B, 0xC8, 0xA3 };
+    DWORD addr = SearchAndGetAddresses(0x004477DD, 0x0044797D, 0x0044797D, SearchBytesDeltaFrame, sizeof(SearchBytesDeltaFrame), -0x4);
+    if (!addr)
+    {
+        Logging::Log() << __FUNCTION__ << "Error: failed to find memory address!";
+        return 0;
+    }
+    DWORD result = 0;
+    memcpy(&result, (DWORD*)addr, sizeof(DWORD));
+    return result;
+}
+
+// Patch map transcription animation to play at the correct rate at 60 FPS.
+void PatchMapTranscription()
+{
+    constexpr BYTE SearchBytesMarkerStateHandler[]{ 0x8B, 0xD1, 0xC1, 0xFA, 0x13, 0x81, 0xE2, 0xFF, 0x1F, 0x00, 0x00 };
+    DWORD MarkerStateHandlerAddr = SearchAndGetAddresses(0x0049C644, 0x0049C8F4, 0x0049C1B4, SearchBytesMarkerStateHandler, sizeof(SearchBytesMarkerStateHandler), -0x10);
+    if (!MarkerStateHandlerAddr)
+    {
+        Logging::Log() << __FUNCTION__ << "Error: failed to find memory address!";
+        return;
+    }
+
+    memcpy(&StateJumpTableAddr, (DWORD*)(MarkerStateHandlerAddr + 0x03), sizeof(DWORD));
+    memcpy(&ActiveMarkerStateAddr, (DWORD*)(MarkerStateHandlerAddr + 0x54), sizeof(DWORD));
+    memcpy(&PauseCounterAddr, (DWORD*)(MarkerStateHandlerAddr + 0x6D), sizeof(DWORD));
+    memcpy(&ZoomOrPanStateAddr, (DWORD*)(MarkerStateHandlerAddr + 0xA2), sizeof(DWORD));
+    memcpy(&MarkerIndexAddr, (DWORD*)(MarkerStateHandlerAddr + 0xBD), sizeof(DWORD));
+    State4ReturnAddr = MarkerStateHandlerAddr + 0xFD;
+
+    constexpr BYTE SearchBytesZoomPanTimerMaxValue[]{ 0x83, 0xEC, 0x10, 0x83, 0xF8, 0x01, 0x75 };
+    DWORD ZoomTimerMaxWriteAddr = SearchAndGetAddresses(0x0049DC35, 0x0049DEE5, 0x0049D7A5, SearchBytesZoomPanTimerMaxValue, sizeof(SearchBytesZoomPanTimerMaxValue), 0x1B);
+    if (!ZoomTimerMaxWriteAddr)
+    {
+        Logging::Log() << __FUNCTION__ << "Error: failed to find memory address!";
+        return;
+    }
+    DWORD PanTimerMaxWriteAddr = ZoomTimerMaxWriteAddr + 0x68;
+    float* ZoomPanTimerMaxValuePtr = &ZoomPanTimerMaxValue;
+
+    DeltaFrameAddr = GetDeltaFrameAddress();
+    if (DeltaFrameAddr == 0) {
+        return;
+    }
+
+    Logging::Log() << "Enabling Map Transcribe Animation Speed Fix...";
+    WriteJMPtoMemory((BYTE*)MarkerStateHandlerAddr, *ActiveMarkerStateASM, 0x07);
+    UpdateMemoryAddress((DWORD*)ZoomTimerMaxWriteAddr, &ZoomPanTimerMaxValuePtr, sizeof(float));
+    UpdateMemoryAddress((DWORD*)PanTimerMaxWriteAddr, &ZoomPanTimerMaxValuePtr, sizeof(float));
+}

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -150,6 +150,7 @@ void PatchSaveBGImage();
 void PatchSpeakerConfigLock();
 void PatchSpecialFX();
 void PatchSpecular();
+void PatchSprayEffect();
 void PatchSFXAddr();
 void PatchSixtyFPS();
 void PatchSpecificSoundLoopFix();

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -139,6 +139,7 @@ void PatchMemoBrightnes();
 void PatchPauseScreen();
 void PatchPistonRoom();
 void PatchPreventChainsawSpawn();
+void PatchPrisonerTimer();
 void PatchPS2Flashlight();
 void PatchPS2NoiseFilter();
 void PatchRedCrossInCutscene();

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -135,6 +135,7 @@ void PatchInventoryBGMBug();
 void PatchLockScreenPosition();
 void PatchMainMenu();
 void PatchMainMenuTitlePerLang();
+void PatchMapTranscription();
 void PatchMemoBrightnes();
 void PatchPauseScreen();
 void PatchPistonRoom();

--- a/Patches/PrisonerTimer.cpp
+++ b/Patches/PrisonerTimer.cpp
@@ -1,0 +1,47 @@
+/**
+* Copyright (C) 2022 Elisha Riedlinger
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+// ASM function to modify the prisoner timer after reset
+__declspec(naked) void __stdcall PrisonerTimerResetASM()
+{
+    __asm
+    {
+        sal dword ptr[esi + 0xA0], 1  // Multiply prisoner timer by 2
+        ret
+    }
+}
+
+// Modify the value of the "Ritual" prisoner timer to fix the footstep rate
+void PatchPrisonerTimer()
+{
+    // Get Prisoner Timer Reset address
+    constexpr BYTE SearchBytesPrisonerTimerReset[]{ 0x89, 0x86, 0xA0, 0x00, 0x00, 0x00, 0xD9, 0x1C, 0x24, 0xE8 };
+    DWORD PrisonerTimerResetAddr = SearchAndGetAddresses(0x004AE5F8, 0x004AE8A8, 0x004AE168, SearchBytesPrisonerTimerReset, sizeof(SearchBytesPrisonerTimerReset), 0x1D);
+    if (!PrisonerTimerResetAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address!";
+        return;
+    }
+
+    Logging::Log() << "Enabling Prisoner Timer Fix...";
+    WriteJMPtoMemory((BYTE*)PrisonerTimerResetAddr, *PrisonerTimerResetASM, 0x5);
+}

--- a/Patches/SixtyFPSPatch.cpp
+++ b/Patches/SixtyFPSPatch.cpp
@@ -139,4 +139,6 @@ void PatchSixtyFPS()
 	PatchStaircaseFlamesLighting();
 
 	PatchWaterLevelSpeed();
+
+	PatchPrisonerTimer();
 }

--- a/Patches/SixtyFPSPatch.cpp
+++ b/Patches/SixtyFPSPatch.cpp
@@ -141,4 +141,6 @@ void PatchSixtyFPS()
 	PatchWaterLevelSpeed();
 
 	PatchPrisonerTimer();
+
+	PatchSprayEffect();
 }

--- a/Patches/SixtyFPSPatch.cpp
+++ b/Patches/SixtyFPSPatch.cpp
@@ -143,4 +143,6 @@ void PatchSixtyFPS()
 	PatchPrisonerTimer();
 
 	PatchSprayEffect();
+
+	PatchMapTranscription();
 }

--- a/Patches/SprayEffect.cpp
+++ b/Patches/SprayEffect.cpp
@@ -1,0 +1,276 @@
+/**
+* Copyright (C) 2022 Elisha Riedlinger
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+constexpr float LyingFigureSpraySpeedFactor0 = 0.1f;    // 30 FPS => 0.2f,   60 FPS => 0.1f
+constexpr float LyingFigureSpraySpeedFactor1 = 0.125f;  // 30 FPS => 0.25f,  60 FPS => 0.125f 
+constexpr float LyingFigureSpraySpeedFactor2 = 0.15f;   // 30 FPS => 0.3f,   60 FPS => 0.15f
+constexpr float HyperSpraySpeedFactor0_1 = 0.15f;       // 30 FPS => 0.3f,   60 FPS => 0.15f
+constexpr float HyperSpraySpeedFactor2 = 0.25f;         // 30 FPS => 0.5f,   60 FPS => 0.25f
+constexpr float SprayYAdjust = 50.0f;                   // 30 FPS => 100.0f, 60 FPS => 50.0f
+
+DWORD* LyingFigureSprayAllocReturnAddr = nullptr;
+DWORD* LyingFigureSprayHandlerAddr = nullptr;
+DWORD* HyperSprayAllocReturnAddr = nullptr;
+DWORD* HyperSprayHandlerAddr = nullptr;
+
+DWORD* ParticleTableAddr = nullptr;
+DWORD* FrameCounterAddr = nullptr;
+
+DWORD SprayFrameCounter = 0;
+DWORD IsSprayActive = 0;
+
+// ASM function to spawn a spray effect particle every other frame
+__declspec(naked) void __stdcall IsSprayAllocActiveASM()
+{
+    __asm
+    {
+        mov eax, 5
+        mov edx, dword ptr ds : [ParticleTableAddr]
+        mov eax, dword ptr ds : [eax * 4 + edx]
+        mov edx, dword ptr ds : [eax + 4]
+        cmp eax, edx  // At least 1 particle allocated?
+        jnz CheckFrameCount
+        mov dword ptr ds : [IsSprayActive] , 1
+        jmp ExitASM
+
+        CheckFrameCount :
+        mov eax, dword ptr ds : [FrameCounterAddr]
+            mov eax, dword ptr ds : [eax]
+            mov edx, dword ptr ds : [SprayFrameCounter]
+            cmp eax, edx  // Is this a new frame?
+            jz LoadActive
+            mov dword ptr ds : [SprayFrameCounter] , eax
+            mov eax, dword ptr ds : [IsSprayActive]
+            xor eax, 1
+            mov dword ptr ds : [IsSprayActive] , eax
+            jmp CheckActive
+
+            LoadActive :
+        mov eax, dword ptr ds : [IsSprayActive]
+            test eax, eax
+            CheckActive :
+        jnz ExitASM
+            mov eax, 0  // Inactive
+            ret
+
+            ExitASM :
+        mov eax, 1  // Active
+            ret
+    }
+}
+
+__declspec(naked) void __stdcall LyingFigureSprayAllocASM()
+{
+    __asm
+    {
+        call IsSprayAllocActiveASM
+        test eax, eax
+        jnz ExitASM
+        ret  // Skip allocating a new particle this frame
+
+        ExitASM :
+        push esi
+            push 5
+            mov eax, dword ptr ds : [LyingFigureSprayHandlerAddr]
+            push eax
+            jmp LyingFigureSprayAllocReturnAddr
+    }
+}
+
+__declspec(naked) void __stdcall HyperSprayAllocASM()
+{
+    __asm
+    {
+        call IsSprayAllocActiveASM
+        test eax, eax
+        jnz ExitASM
+        ret  // Skip allocating a new particle this frame
+
+        ExitASM :
+        push esi
+            push 5
+            mov eax, dword ptr ds : [HyperSprayHandlerAddr]
+            push eax
+            jmp HyperSprayAllocReturnAddr
+    }
+}
+
+bool WritePointerToMemory(void* dataAddr, const void* dataPtr) {
+    return UpdateMemoryAddress(dataAddr, &dataPtr, sizeof(DWORD*));
+}
+
+DWORD* GetParticleTableAddr()
+{
+    constexpr BYTE ParticleTableAddrSearchBytes[]{ 0x0F, 0xB6, 0x44, 0x24, 0x08, 0x8B, 0x0C, 0x85 };
+    DWORD* addr = (DWORD*)ReadSearchedAddresses(0x00570B80, 0x00571430, 0x00570D50, ParticleTableAddrSearchBytes, sizeof(ParticleTableAddrSearchBytes), 0x8);
+    if (addr == nullptr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for the particle table!";
+        return nullptr;
+    }
+    return addr;
+}
+
+DWORD* GetFrameCounterAddr()
+{
+    constexpr BYTE FrameCounterAddrSearchBytes[]{ 0x8B, 0xC8, 0x2B, 0xC2, 0x89, 0x0D };
+    DWORD* addr = (DWORD*)ReadSearchedAddresses(0x0044932B, 0x004494CB, 0x004494CB, FrameCounterAddrSearchBytes, sizeof(FrameCounterAddrSearchBytes), 0x6);
+    if (addr == nullptr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for the frame counter!";
+        return nullptr;
+    }
+    return addr;
+}
+
+// Reduce the speed of Lying Figure spray particles by half
+void PatchLyingFigureSprayEffectSpeed()
+{
+    constexpr BYTE State0SearchBytes[]{ 0xDB, 0x46, 0x18, 0x6A, 0x06, 0xD9, 0x5C, 0x24, 0x14, 0xE8 };
+    const DWORD SpraySpeedFactorState0Addr = SearchAndGetAddresses(0x004A40CD, 0x004A437D, 0x004A3C3D, State0SearchBytes, sizeof(State0SearchBytes), 0x25);
+    if (!SpraySpeedFactorState0Addr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 0!";
+        return;
+    }
+
+    constexpr BYTE State1SearchBytes[]{ 0x6A, 0x06, 0xD8, 0x7C, 0x24, 0x1C, 0xD9, 0x5C, 0x24, 0x34, 0xD9, 0x46, 0x48, 0xD8, 0x0D };
+    const DWORD SpraySpeedFactorState1Addr = SearchAndGetAddresses(0x004A401A, 0x004A42CA, 0x004A3B8A, State1SearchBytes, sizeof(State1SearchBytes), 0xF);
+    if (!SpraySpeedFactorState1Addr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 1!";
+        return;
+    }
+    const DWORD SprayYAdjustState1Addr = SpraySpeedFactorState1Addr + 0x39;
+
+    constexpr BYTE State2SearchBytes[]{ 0x6A, 0x0A, 0xD8, 0x7C, 0x24, 0x1C, 0xD9, 0x5C, 0x24, 0x38, 0xD9, 0x46, 0x48, 0xD8, 0x0D };
+    const DWORD SpraySpeedFactorState2Addr = SearchAndGetAddresses(0x004A3F15, 0x004A41C5, 0x004A3A85, State2SearchBytes, sizeof(State2SearchBytes), 0xF);
+    if (!SpraySpeedFactorState2Addr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 2!";
+        return;
+    }
+    const DWORD SprayYAdjustState2Addr = SpraySpeedFactorState2Addr + 0x39;
+
+    WritePointerToMemory((void*)SpraySpeedFactorState0Addr, (void*)&LyingFigureSpraySpeedFactor0);
+    WritePointerToMemory((void*)SpraySpeedFactorState1Addr, (void*)&LyingFigureSpraySpeedFactor1);
+    WritePointerToMemory((void*)SpraySpeedFactorState2Addr, (void*)&LyingFigureSpraySpeedFactor2);
+    WritePointerToMemory((void*)SprayYAdjustState1Addr, (void*)&SprayYAdjust);
+    WritePointerToMemory((void*)SprayYAdjustState2Addr, (void*)&SprayYAdjust);
+}
+
+// Patch in logic to spawn spray particles for the Lying Figure every other frame
+void PatchLyingFigureSprayEffectSpawnRate()
+{
+    constexpr BYTE SprayAllocAddrSearchBytes[]{ 0x8B, 0xF0, 0x83, 0xC4, 0x08, 0x85, 0xF6, 0x0F };
+    DWORD SprayAllocAddr = SearchAndGetAddresses(0x004A4A1D, 0x004A4CCD, 0x004A458D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0xD);
+    if (!SprayAllocAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray alloc handler!";
+        return;
+    }
+    LyingFigureSprayAllocReturnAddr = (DWORD*)(SprayAllocAddr + 0x8);
+
+    LyingFigureSprayHandlerAddr = (DWORD*)ReadSearchedAddresses(0x004A4A1D, 0x004A4CCD, 0x004A458D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x9);
+    if (!LyingFigureSprayHandlerAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray handler!";
+        return;
+    }
+
+    WriteJMPtoMemory((BYTE*)SprayAllocAddr, *LyingFigureSprayAllocASM, 0x08);
+}
+
+// Reduce the speed of Hyper Spray particles by half
+void PatchHyperSprayEffectSpeed()
+{
+    constexpr BYTE State0SearchBytes[]{ 0xDB, 0x46, 0x18, 0xD8, 0xC9, 0xD9, 0xC9, 0xD8, 0x4E, 0x54, 0xD8, 0x0D };
+    const DWORD SpraySpeedFactorState0Addr = SearchAndGetAddresses(0x004A4579, 0x004A4829, 0x004A40E9, State0SearchBytes, sizeof(State0SearchBytes), 0xC);
+    if (!SpraySpeedFactorState0Addr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 0!";
+        return;
+    }
+
+    constexpr BYTE State1SearchBytes[]{ 0x89, 0x44, 0x24, 0x18, 0xDB, 0x44, 0x24, 0x18, 0xD8, 0xC9, 0xD9, 0x5C, 0x24, 0x18, 0xD8, 0x4E, 0x54, 0xD8, 0x0D };
+    const DWORD SpraySpeedFactorState1Addr = SearchAndGetAddresses(0x004A44EC, 0x004A479C, 0x004A405C, State1SearchBytes, sizeof(State1SearchBytes), 0x13);
+    if (!SpraySpeedFactorState1Addr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 1!";
+        return;
+    }
+    const DWORD SprayYAdjustState1Addr = SpraySpeedFactorState1Addr + 0x24;
+
+    constexpr BYTE State2SearchBytes[]{ 0xDB, 0x44, 0x24, 0x18, 0xD8, 0xC9, 0xD9, 0x5C, 0x24, 0x18, 0xD8, 0x4E, 0x54, 0xD8, 0x0D };
+    const DWORD SpraySpeedFactorState2Addr = SearchAndGetAddresses(0x004A442C, 0x004A46DC, 0x004A3F9C, State2SearchBytes, sizeof(State2SearchBytes), 0xF);
+    if (!SpraySpeedFactorState2Addr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 2!";
+        return;
+    }
+    const DWORD SprayYAdjustState2Addr = SpraySpeedFactorState2Addr + 0x24;
+
+    WritePointerToMemory((void*)SpraySpeedFactorState0Addr, (void*)&HyperSpraySpeedFactor0_1);
+    WritePointerToMemory((void*)SpraySpeedFactorState1Addr, (void*)&HyperSpraySpeedFactor0_1);
+    WritePointerToMemory((void*)SpraySpeedFactorState2Addr, (void*)&HyperSpraySpeedFactor2);
+    WritePointerToMemory((void*)SprayYAdjustState1Addr, (void*)&SprayYAdjust);
+    WritePointerToMemory((void*)SprayYAdjustState2Addr, (void*)&SprayYAdjust);
+}
+
+// Patch in logic to spawn Hyper Spray particles every other frame
+void PatchHyperSprayEffectSpawnRate()
+{
+    constexpr BYTE SprayAllocAddrSearchBytes[]{ 0x8B, 0xF0, 0x33, 0xC9, 0x83, 0xC4, 0x08, 0x3B, 0xF1, 0x0F };
+
+    DWORD SprayAllocAddr = SearchAndGetAddresses(0x004A509D, 0x004A534D, 0x004A4C0D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0xD);
+    if (!SprayAllocAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray alloc handler!";
+        return;
+    }
+    HyperSprayAllocReturnAddr = (DWORD*)(SprayAllocAddr + 0x8);
+
+    HyperSprayHandlerAddr = (DWORD*)ReadSearchedAddresses(0x004A509D, 0x004A534D, 0x004A4C0D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x9);
+    if (!HyperSprayHandlerAddr)
+    {
+        Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray handler!";
+        return;
+    }
+
+    WriteJMPtoMemory((BYTE*)SprayAllocAddr, *HyperSprayAllocASM, 0x08);
+}
+
+// Patch spray effects when playing at 60 FPS
+void PatchSprayEffect()
+{
+    Logging::Log() << "Enabling Lying Figure Spray Effect Fix...";
+    ParticleTableAddr = GetParticleTableAddr();
+    FrameCounterAddr = GetFrameCounterAddr();
+    if (ParticleTableAddr == nullptr || FrameCounterAddr == nullptr)
+        return;
+    PatchLyingFigureSprayEffectSpeed();
+    PatchLyingFigureSprayEffectSpawnRate();
+
+    Logging::Log() << "Enabling Hyper Spray Effect Fix...";
+    PatchHyperSprayEffectSpeed();
+    PatchHyperSprayEffectSpawnRate();
+}

--- a/Patches/SprayEffect.cpp
+++ b/Patches/SprayEffect.cpp
@@ -49,32 +49,32 @@ __declspec(naked) void __stdcall IsSprayAllocActiveASM()
         mov edx, dword ptr ds : [eax + 4]
         cmp eax, edx  // At least 1 particle allocated?
         jnz CheckFrameCount
-        mov dword ptr ds : [IsSprayActive] , 1
+        mov dword ptr ds : [IsSprayActive], 1
         jmp ExitASM
 
-        CheckFrameCount :
+    CheckFrameCount:
         mov eax, dword ptr ds : [FrameCounterAddr]
-            mov eax, dword ptr ds : [eax]
-            mov edx, dword ptr ds : [SprayFrameCounter]
-            cmp eax, edx  // Is this a new frame?
-            jz LoadActive
-            mov dword ptr ds : [SprayFrameCounter] , eax
-            mov eax, dword ptr ds : [IsSprayActive]
-            xor eax, 1
-            mov dword ptr ds : [IsSprayActive] , eax
-            jmp CheckActive
-
-            LoadActive :
+        mov eax, dword ptr ds : [eax]
+        mov edx, dword ptr ds : [SprayFrameCounter]
+        cmp eax, edx  // Is this a new frame?
+        jz LoadActive
+        mov dword ptr ds : [SprayFrameCounter], eax
         mov eax, dword ptr ds : [IsSprayActive]
-            test eax, eax
-            CheckActive :
-        jnz ExitASM
-            mov eax, 0  // Inactive
-            ret
+        xor eax, 1
+        mov dword ptr ds : [IsSprayActive], eax
+        jmp CheckActive
 
-            ExitASM :
+    LoadActive:
+        mov eax, dword ptr ds : [IsSprayActive]
+        test eax, eax
+    CheckActive:
+        jnz ExitASM
+        mov eax, 0  // Inactive
+        ret
+
+    ExitASM:
         mov eax, 1  // Active
-            ret
+        ret
     }
 }
 
@@ -87,12 +87,12 @@ __declspec(naked) void __stdcall LyingFigureSprayAllocASM()
         jnz ExitASM
         ret  // Skip allocating a new particle this frame
 
-        ExitASM :
+    ExitASM:
         push esi
-            push 5
-            mov eax, dword ptr ds : [LyingFigureSprayHandlerAddr]
-            push eax
-            jmp LyingFigureSprayAllocReturnAddr
+        push 5
+        mov eax, dword ptr ds : [LyingFigureSprayHandlerAddr]
+        push eax
+        jmp LyingFigureSprayAllocReturnAddr
     }
 }
 
@@ -105,12 +105,12 @@ __declspec(naked) void __stdcall HyperSprayAllocASM()
         jnz ExitASM
         ret  // Skip allocating a new particle this frame
 
-        ExitASM :
+    ExitASM:
         push esi
-            push 5
-            mov eax, dword ptr ds : [HyperSprayHandlerAddr]
-            push eax
-            jmp HyperSprayAllocReturnAddr
+        push 5
+        mov eax, dword ptr ds : [HyperSprayHandlerAddr]
+        push eax
+        jmp HyperSprayAllocReturnAddr
     }
 }
 

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="Patches\AlternateStomp.cpp" />
     <ClCompile Include="Patches\ChangeClosetSpawn.cpp" />
     <ClCompile Include="Patches\PatchCriware.cpp" />
+    <ClCompile Include="Patches\PrisonerTimer.cpp" />
     <ClCompile Include="Patches\SaveGameSound.cpp" />
     <ClCompile Include="Logging\Logging.cpp" />
     <ClCompile Include="Patches\2TBHardDriveFix.cpp" />

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="Include\criware\criware_xaudio2.cpp" />
     <ClCompile Include="Patches\AlternateStomp.cpp" />
     <ClCompile Include="Patches\ChangeClosetSpawn.cpp" />
+    <ClCompile Include="Patches\MapTranscription.cpp" />
     <ClCompile Include="Patches\PatchCriware.cpp" />
     <ClCompile Include="Patches\PrisonerTimer.cpp" />
     <ClCompile Include="Patches\SaveGameSound.cpp" />

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="Patches\SixtyFPSPatch.cpp" />
     <ClCompile Include="Patches\SpecialFX.cpp" />
     <ClCompile Include="Patches\Specular.cpp" />
+    <ClCompile Include="Patches\SprayEffect.cpp" />
     <ClCompile Include="Patches\TexPatch.cpp" />
     <ClCompile Include="Patches\FogAdjustments.cpp" />
     <ClCompile Include="Patches\Fonts.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -365,6 +365,9 @@
     <ClCompile Include="Patches\SprayEffect.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\MapTranscription.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -362,6 +362,9 @@
     <ClCompile Include="Patches\PrisonerTimer.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\SprayEffect.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -359,6 +359,9 @@
     <ClCompile Include="Patches\SixtyFPSPatch.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\PrisonerTimer.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
Adding fixes for the below [60 FPS issues](https://github.com/elishacloud/Silent-Hill-2-Enhancements/issues/28) so we can test these all in one place:

> * The "Ritual" prison monster's footsteps go crazy fast.
> * The animation process whenever James transcribes notes onto his map is twice as fast (too fast).
> * The visual range of the Lying Figure's spray attack is twice as long. The spray can look like it's hitting James when it actually isn't.
> * The visual range of the Hyper Spray's spray is twice as long. The spray can look like it's hitting enemies when it actually isn't.

These are ready to test for v1.0, v1.1 and DC.