### PR TITLE
Add 60 FPS patch for enemy hold damage

### DIFF
--- a/Patches/HoldDamage.cpp
+++ b/Patches/HoldDamage.cpp
@@ -1,0 +1,76 @@
+/**
+* Copyright (C) 2022 Murugo
+*
+* This software is  provided 'as-is', without any express  or implied  warranty. In no event will the
+* authors be held liable for any damages arising from the use of this software.
+* Permission  is granted  to anyone  to use  this software  for  any  purpose,  including  commercial
+* applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*   1. The origin of this software must not be misrepresented; you must not claim that you  wrote the
+*      original  software. If you use this  software  in a product, an  acknowledgment in the product
+*      documentation would be appreciated but is not required.
+*   2. Altered source versions must  be plainly  marked as such, and  must not be  misrepresented  as
+*      being the original software.
+*   3. This notice may not be removed or altered from any source distribution.
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "Patches.h"
+#include "Common\Utils.h"
+#include "Logging\Logging.h"
+
+DWORD DeltaTimeFuncAddr = 0;
+float DamageScale = 30.0f;
+
+// ASM which scales enemy damage by delta time while the player is in a hold attack.
+__declspec(naked) void __stdcall ScaleHoldDamageASM()
+{
+    __asm
+    {
+        push eax
+        mov eax, dword ptr ds : [DeltaTimeFuncAddr]
+        call eax  // Pushes delta time to st(0)
+        fmul dword ptr ds : [DamageScale]
+        fmul dword ptr ds : [esi + 0x11C]  // Multiply by enemy damage
+        fsubp st(1), st(0)
+        pop eax
+        ret
+    }
+}
+
+DWORD GetDeltaTimeFuncAddress()
+{
+    constexpr BYTE SearchBytes[]{ 0x83, 0xEC, 0x48, 0x53, 0x56, 0x33, 0xDB, 0x3B, 0xC3, 0x57 };
+    DWORD Addr = SearchAndGetAddresses(0x00479080, 0x00479320, 0x00479530, SearchBytes, sizeof(SearchBytes), 0x23);
+    if (!Addr)
+    {
+        Logging::Log() << __FUNCTION__ << "Error: failed to find memory address!";
+        return 0;
+    }
+    DWORD RelativeFuncAddr = 0;
+    memcpy(&RelativeFuncAddr, (void*)(Addr - 0x4), sizeof(DWORD));
+    return Addr + RelativeFuncAddr;
+}
+
+// Patch how much damage an enemy hold attack will inflict every frame by scaling damage with the current frame rate.
+// Affects hold damage rate for Flesh Lips, Abstract Daddy, and the final boss (tentacle choke and moth attack).
+void PatchHoldDamage()
+{
+    constexpr BYTE SearchBytesApplyHoldDamage[]{ 0xD9, 0x86, 0x3C, 0x01, 0x00, 0x00, 0x8B, 0x96, 0x1C, 0x01, 0x00, 0x00 };
+    DWORD ApplyHoldDamageAddr = SearchAndGetAddresses(0x005359D5, 0x00535D05, 0x00535625, SearchBytesApplyHoldDamage, sizeof(SearchBytesApplyHoldDamage), 0x0C);
+    if (!ApplyHoldDamageAddr)
+    {
+        Logging::Log() << __FUNCTION__ << "Error: failed to find memory address!";
+        return;
+    }
+
+    DeltaTimeFuncAddr = GetDeltaTimeFuncAddress();
+    if (!DeltaTimeFuncAddr)
+    {
+        return;
+    }
+
+    Logging::Log() << "Enabling Enemy Hold Damage Fix...";
+    WriteCalltoMemory((BYTE*)ApplyHoldDamageAddr, *ScaleHoldDamageASM, 0x06);
+}

--- a/Patches/MapTranscription.cpp
+++ b/Patches/MapTranscription.cpp
@@ -134,7 +134,7 @@ __declspec(naked) void __stdcall ActiveMarkerStateASM()
         pop edx
         mov dword ptr ds : [eax], ecx
         mov eax, 0x00
-        cmp ecx, [esp + 0x8]
+        cmp ecx, [esp + 0x08]
         pop ecx
         jge PauseForFramesDone
         ret
@@ -159,15 +159,13 @@ __declspec(naked) void __stdcall ActiveMarkerStateASM()
 DWORD GetDeltaFrameAddress()
 {
     constexpr BYTE SearchBytesDeltaFrame[]{ 0x8B, 0x44, 0x24, 0x04, 0x8B, 0xC8, 0xA3 };
-    DWORD addr = SearchAndGetAddresses(0x004477DD, 0x0044797D, 0x0044797D, SearchBytesDeltaFrame, sizeof(SearchBytesDeltaFrame), -0x4);
-    if (!addr)
+    DWORD Addr = ReadSearchedAddresses(0x004477DD, 0x0044797D, 0x0044797D, SearchBytesDeltaFrame, sizeof(SearchBytesDeltaFrame), -0x04);
+    if (!Addr)
     {
         Logging::Log() << __FUNCTION__ << "Error: failed to find memory address!";
         return 0;
     }
-    DWORD result = 0;
-    memcpy(&result, (DWORD*)addr, sizeof(DWORD));
-    return result;
+    return Addr;
 }
 
 // Patch map transcription animation to play at the correct rate at 60 FPS.
@@ -199,7 +197,8 @@ void PatchMapTranscription()
     float* ZoomPanTimerMaxValuePtr = &ZoomPanTimerMaxValue;
 
     DeltaFrameAddr = GetDeltaFrameAddress();
-    if (DeltaFrameAddr == 0) {
+    if (DeltaFrameAddr == 0)
+    {
         return;
     }
 

--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -134,6 +134,7 @@ void PatchFogParameters();
 void PatchFullscreenImages();
 void PatchFullscreenVideos();
 void PatchGameLoad();
+void PatchHoldDamage();
 void PatchInventoryBGMBug();
 void PatchLockScreenPosition();
 void PatchMainMenu();

--- a/Patches/PrisonerTimer.cpp
+++ b/Patches/PrisonerTimer.cpp
@@ -30,7 +30,7 @@ __declspec(naked) void __stdcall PrisonerTimerResetASM()
     }
 }
 
-// Modify the value of the "Ritual" prisoner timer to fix the footstep rate
+// Modify the value of the "Ritual" prisoner timer to fix the footstep rate at 60 FPS
 void PatchPrisonerTimer()
 {
     // Get Prisoner Timer Reset address
@@ -43,5 +43,5 @@ void PatchPrisonerTimer()
     }
 
     Logging::Log() << "Enabling Prisoner Timer Fix...";
-    WriteJMPtoMemory((BYTE*)PrisonerTimerResetAddr, *PrisonerTimerResetASM, 0x5);
+    WriteJMPtoMemory((BYTE*)PrisonerTimerResetAddr, *PrisonerTimerResetASM, 0x05);
 }

--- a/Patches/SixtyFPSPatch.cpp
+++ b/Patches/SixtyFPSPatch.cpp
@@ -119,23 +119,6 @@ float __cdecl GetDoubledAnimationRate_Hook()
 	return GetFogAnimationRate.fun() * 2;
 }
 
-/*
-__declspec(naked) void __cdecl DivideGrabDamageByTwoASM()
-{
-	__asm
-	{
-		fld dword ptr[esi + 0x11C]
-		fmul dword ptr[]  // Multiply damage by 0.5f
-		fld dword ptr[esi + 0x13C]
-		fsub st, st(1)
-		fstp dword ptr[esi + 0x13C]
-		mov edx, [esi + 0x13C]
-		push edx
-		jmp 0x400000 + 0x1359EE // TODO change base address?
-	}
-}
-*/
-
 void PatchSixtyFPS()
 {
 	Logging::Log() << "Applying Fixes for 60 FPS...";
@@ -197,8 +180,6 @@ void PatchSixtyFPS()
 		Logging::Log() << __FUNCTION__ << " Error: failed to find Bullet Animation Rate Four Function address!";
 	}
 
-	//WriteJMPtoMemory((BYTE*)GetGrabDamagePointer(), *DivideGrabDamageByTwoASM, 5);
-
 	Logging::Log() << "Patching motion blur...";
 	MotionBlurValue = MotionBlurOvrd;
 
@@ -219,6 +200,8 @@ void PatchSixtyFPS()
 	PatchMapTranscription();
 
 	PatchBugRoomFlashlight();
+
+    PatchHoldDamage();
 
 	PatchFMV();
 

--- a/Patches/SprayEffect.cpp
+++ b/Patches/SprayEffect.cpp
@@ -121,25 +121,25 @@ bool WritePointerToMemory(void* dataAddr, const void* dataPtr) {
 DWORD* GetParticleTableAddr()
 {
     constexpr BYTE ParticleTableAddrSearchBytes[]{ 0x0F, 0xB6, 0x44, 0x24, 0x08, 0x8B, 0x0C, 0x85 };
-    DWORD* addr = (DWORD*)ReadSearchedAddresses(0x00570B80, 0x00571430, 0x00570D50, ParticleTableAddrSearchBytes, sizeof(ParticleTableAddrSearchBytes), 0x8);
-    if (addr == nullptr)
+    DWORD* Addr = (DWORD*)ReadSearchedAddresses(0x00570B80, 0x00571430, 0x00570D50, ParticleTableAddrSearchBytes, sizeof(ParticleTableAddrSearchBytes), 0x08);
+    if (Addr == nullptr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for the particle table!";
         return nullptr;
     }
-    return addr;
+    return Addr;
 }
 
 DWORD* GetFrameCounterAddr()
 {
     constexpr BYTE FrameCounterAddrSearchBytes[]{ 0x8B, 0xC8, 0x2B, 0xC2, 0x89, 0x0D };
-    DWORD* addr = (DWORD*)ReadSearchedAddresses(0x0044932B, 0x004494CB, 0x004494CB, FrameCounterAddrSearchBytes, sizeof(FrameCounterAddrSearchBytes), 0x6);
-    if (addr == nullptr)
+    DWORD* Addr = (DWORD*)ReadSearchedAddresses(0x0044932B, 0x004494CB, 0x004494CB, FrameCounterAddrSearchBytes, sizeof(FrameCounterAddrSearchBytes), 0x06);
+    if (Addr == nullptr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for the frame counter!";
         return nullptr;
     }
-    return addr;
+    return Addr;
 }
 
 // Reduce the speed of Lying Figure spray particles by half
@@ -154,7 +154,7 @@ void PatchLyingFigureSprayEffectSpeed()
     }
 
     constexpr BYTE State1SearchBytes[]{ 0x6A, 0x06, 0xD8, 0x7C, 0x24, 0x1C, 0xD9, 0x5C, 0x24, 0x34, 0xD9, 0x46, 0x48, 0xD8, 0x0D };
-    const DWORD SpraySpeedFactorState1Addr = SearchAndGetAddresses(0x004A401A, 0x004A42CA, 0x004A3B8A, State1SearchBytes, sizeof(State1SearchBytes), 0xF);
+    const DWORD SpraySpeedFactorState1Addr = SearchAndGetAddresses(0x004A401A, 0x004A42CA, 0x004A3B8A, State1SearchBytes, sizeof(State1SearchBytes), 0x0F);
     if (!SpraySpeedFactorState1Addr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 1!";
@@ -163,7 +163,7 @@ void PatchLyingFigureSprayEffectSpeed()
     const DWORD SprayYAdjustState1Addr = SpraySpeedFactorState1Addr + 0x39;
 
     constexpr BYTE State2SearchBytes[]{ 0x6A, 0x0A, 0xD8, 0x7C, 0x24, 0x1C, 0xD9, 0x5C, 0x24, 0x38, 0xD9, 0x46, 0x48, 0xD8, 0x0D };
-    const DWORD SpraySpeedFactorState2Addr = SearchAndGetAddresses(0x004A3F15, 0x004A41C5, 0x004A3A85, State2SearchBytes, sizeof(State2SearchBytes), 0xF);
+    const DWORD SpraySpeedFactorState2Addr = SearchAndGetAddresses(0x004A3F15, 0x004A41C5, 0x004A3A85, State2SearchBytes, sizeof(State2SearchBytes), 0x0F);
     if (!SpraySpeedFactorState2Addr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 2!";
@@ -182,15 +182,15 @@ void PatchLyingFigureSprayEffectSpeed()
 void PatchLyingFigureSprayEffectSpawnRate()
 {
     constexpr BYTE SprayAllocAddrSearchBytes[]{ 0x8B, 0xF0, 0x83, 0xC4, 0x08, 0x85, 0xF6, 0x0F };
-    DWORD SprayAllocAddr = SearchAndGetAddresses(0x004A4A1D, 0x004A4CCD, 0x004A458D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0xD);
+    DWORD SprayAllocAddr = SearchAndGetAddresses(0x004A4A1D, 0x004A4CCD, 0x004A458D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x0D);
     if (!SprayAllocAddr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray alloc handler!";
         return;
     }
-    LyingFigureSprayAllocReturnAddr = (DWORD*)(SprayAllocAddr + 0x8);
+    LyingFigureSprayAllocReturnAddr = (DWORD*)(SprayAllocAddr + 0x08);
 
-    LyingFigureSprayHandlerAddr = (DWORD*)ReadSearchedAddresses(0x004A4A1D, 0x004A4CCD, 0x004A458D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x9);
+    LyingFigureSprayHandlerAddr = (DWORD*)ReadSearchedAddresses(0x004A4A1D, 0x004A4CCD, 0x004A458D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x09);
     if (!LyingFigureSprayHandlerAddr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray handler!";
@@ -204,7 +204,7 @@ void PatchLyingFigureSprayEffectSpawnRate()
 void PatchHyperSprayEffectSpeed()
 {
     constexpr BYTE State0SearchBytes[]{ 0xDB, 0x46, 0x18, 0xD8, 0xC9, 0xD9, 0xC9, 0xD8, 0x4E, 0x54, 0xD8, 0x0D };
-    const DWORD SpraySpeedFactorState0Addr = SearchAndGetAddresses(0x004A4579, 0x004A4829, 0x004A40E9, State0SearchBytes, sizeof(State0SearchBytes), 0xC);
+    const DWORD SpraySpeedFactorState0Addr = SearchAndGetAddresses(0x004A4579, 0x004A4829, 0x004A40E9, State0SearchBytes, sizeof(State0SearchBytes), 0x0C);
     if (!SpraySpeedFactorState0Addr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 0!";
@@ -221,7 +221,7 @@ void PatchHyperSprayEffectSpeed()
     const DWORD SprayYAdjustState1Addr = SpraySpeedFactorState1Addr + 0x24;
 
     constexpr BYTE State2SearchBytes[]{ 0xDB, 0x44, 0x24, 0x18, 0xD8, 0xC9, 0xD9, 0x5C, 0x24, 0x18, 0xD8, 0x4E, 0x54, 0xD8, 0x0D };
-    const DWORD SpraySpeedFactorState2Addr = SearchAndGetAddresses(0x004A442C, 0x004A46DC, 0x004A3F9C, State2SearchBytes, sizeof(State2SearchBytes), 0xF);
+    const DWORD SpraySpeedFactorState2Addr = SearchAndGetAddresses(0x004A442C, 0x004A46DC, 0x004A3F9C, State2SearchBytes, sizeof(State2SearchBytes), 0x0F);
     if (!SpraySpeedFactorState2Addr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for state 2!";
@@ -241,7 +241,7 @@ void PatchHyperSprayEffectSpawnRate()
 {
     constexpr BYTE SprayAllocAddrSearchBytes[]{ 0x8B, 0xF0, 0x33, 0xC9, 0x83, 0xC4, 0x08, 0x3B, 0xF1, 0x0F };
 
-    DWORD SprayAllocAddr = SearchAndGetAddresses(0x004A509D, 0x004A534D, 0x004A4C0D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0xD);
+    DWORD SprayAllocAddr = SearchAndGetAddresses(0x004A509D, 0x004A534D, 0x004A4C0D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x0D);
     if (!SprayAllocAddr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray alloc handler!";
@@ -249,7 +249,7 @@ void PatchHyperSprayEffectSpawnRate()
     }
     HyperSprayAllocReturnAddr = (DWORD*)(SprayAllocAddr + 0x8);
 
-    HyperSprayHandlerAddr = (DWORD*)ReadSearchedAddresses(0x004A509D, 0x004A534D, 0x004A4C0D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x9);
+    HyperSprayHandlerAddr = (DWORD*)ReadSearchedAddresses(0x004A509D, 0x004A534D, 0x004A4C0D, SprayAllocAddrSearchBytes, sizeof(SprayAllocAddrSearchBytes), -0x09);
     if (!HyperSprayHandlerAddr)
     {
         Logging::Log() << __FUNCTION__ << " Error: failed to find memory address for Lying Figure spray handler!";
@@ -266,7 +266,9 @@ void PatchSprayEffect()
     ParticleTableAddr = GetParticleTableAddr();
     FrameCounterAddr = GetFrameCounterAddr();
     if (ParticleTableAddr == nullptr || FrameCounterAddr == nullptr)
+    {
         return;
+    }
     PatchLyingFigureSprayEffectSpeed();
     PatchLyingFigureSprayEffectSpawnRate();
 

--- a/sh2-enhce.vcxproj
+++ b/sh2-enhce.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="Include\criware\criware_xaudio2.cpp" />
     <ClCompile Include="Patches\AlternateStomp.cpp" />
     <ClCompile Include="Patches\ChangeClosetSpawn.cpp" />
+    <ClCompile Include="Patches\HoldDamage.cpp" />
     <ClCompile Include="Patches\MapTranscription.cpp" />
     <ClCompile Include="Patches\PatchCriware.cpp" />
     <ClCompile Include="Patches\PrisonerTimer.cpp" />

--- a/sh2-enhce.vcxproj.filters
+++ b/sh2-enhce.vcxproj.filters
@@ -368,6 +368,9 @@
     <ClCompile Include="Patches\MapTranscription.cpp">
       <Filter>Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\HoldDamage.cpp">
+      <Filter>Patches</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Common\Settings.h">


### PR DESCRIPTION
Adding a patch for the following [60 FPS issue](https://github.com/elishacloud/Silent-Hill-2-Enhancements/issues/28):

> Enemies that hold you in place for attacks do twice as much damage. This is due to damage being accrued per frame. [This can make the final boss unbeatable in certain situations.](https://twitter.com/danksilenthill/status/1560647022692245506?t=NJRBKFZc6qeYlmfLWfMmYg&s=19)

Ready to test for v1.0, v1.1 and DC. Also includes minor formatting fixes in other files.